### PR TITLE
Fix parser

### DIFF
--- a/src/scene/constructor.c
+++ b/src/scene/constructor.c
@@ -29,10 +29,14 @@ t_object	*new_object(t_object_type type)
 	object = ft_calloc(1, sizeof(t_object));
 	object->type = type;
 	if (type == OBJ_SPHERE)
-		object->conf = ft_xmalloc(sizeof(t_sphere_conf));
+		object->conf = ft_calloc(1, sizeof(t_sphere_conf));
 	else if (type == OBJ_PLANE)
-		object->conf = ft_xmalloc(sizeof(t_plane_conf));
+		object->conf = ft_calloc(1, sizeof(t_plane_conf));
 	else if (type == OBJ_CYLINDER)
-		object->conf = ft_xmalloc(sizeof(t_cylinder_conf));
+		object->conf = ft_calloc(1, sizeof(t_cylinder_conf));
+	else if (type == OBJ_CONE)
+		object->conf = ft_calloc(1, sizeof(t_cone_conf));
+	else if (type == OBJ_CIRCLE)
+		object->conf = ft_calloc(1, sizeof(t_circle_conf));
 	return (object);
 }

--- a/src/scene/parse.c
+++ b/src/scene/parse.c
@@ -74,7 +74,8 @@ t_scene	*parse_scene(const char *path, t_parse_option opt)
 			exit_with_error(EXIT_FAILURE, "failed to read file");
 		if (line == NULL)
 			break ;
-		parse_line(scene, line, &state);
+		if (*line != '\n' && *line != '#')
+			parse_line(scene, line, &state);
 		free(line);
 	}
 	validate_state(state, opt);


### PR DESCRIPTION
改行 or コメント行を読み飛ばすように.
`new_object` が古かったので更新 (使ってないけど).