### PR TITLE
Fix lighting

### DIFF
--- a/scenes/box.rt
+++ b/scenes/box.rt
@@ -1,0 +1,25 @@
+A  0.1  255,255,255
+
+# Camera is placed inside the box, looking towards the back wall
+C  0,0,2  0,0,-1  45
+
+# Light is placed inside the box, near the top
+L  0,2.8,-6  1  255,255,255
+
+# floor
+pl 0,-1,0  0,1,0  176,176,176
+# left wall
+pl -3,0,-5  1,0,0  176,0,0
+# right wall
+pl 3,0,-5  -1,0,0  0,176,0
+# back wall
+pl 0,0,-10  0,0,1  176,176,176
+# ceiling
+pl 0,3,0  0,-1,0  176,176,176
+# front wall
+pl 0,0,4  0,0,-1  176,176,176
+
+# left sphere
+sp -1.5,-0.5,-7  1  255,255,255
+# right sphere
+sp 1.5,-0.5,-7  1  0,0,176

--- a/src/tracer/is_illuminated.c
+++ b/src/tracer/is_illuminated.c
@@ -20,6 +20,8 @@ bool	is_illuminated(t_scene *scene, t_light_conf light, t_hit_record rec)
 	const t_ray		shadow_ray = new_ray(rec.point,
 			vec3_normalize(vec3_sub(light.position, rec.point)));
 
+	if (vec3_dot(rec.normal, shadow_ray.direction) < 0)
+		return (false);
 	obj_node = scene->objects->head;
 	while (obj_node)
 	{

--- a/src/tracer/is_illuminated.c
+++ b/src/tracer/is_illuminated.c
@@ -6,28 +6,36 @@
 /*   By: kemizuki <kemizuki@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/25 06:57:08 by kemizuki          #+#    #+#             */
-/*   Updated: 2023/12/25 22:51:08 by kemizuki         ###   ########.fr       */
+/*   Updated: 2024/01/11 06:08:58 by kemizuki         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "tracer.h"
 
+static bool	blocks_light(t_object *obj, t_ray shadow_ray, double light_dist)
+{
+	const t_hit_func	hit_func = get_hit_func(obj);
+	t_hit_record		shadow_rec;
+
+	if (hit_func != NULL && hit_func(obj, shadow_ray, 1e-3, &shadow_rec)
+		&& shadow_rec.t < light_dist)
+		return (true);
+	return (false);
+}
+
 bool	is_illuminated(t_scene *scene, t_light_conf light, t_hit_record rec)
 {
-	t_hit_func		hit_func;
-	t_hit_record	shadow_rec;
-	t_node			*obj_node;
 	const t_ray		shadow_ray = new_ray(rec.point,
 			vec3_normalize(vec3_sub(light.position, rec.point)));
+	const double	light_dist = vec3_distance(rec.point, light.position);
+	t_node			*obj_node;
 
 	if (vec3_dot(rec.normal, shadow_ray.direction) < 0)
 		return (false);
 	obj_node = scene->objects->head;
 	while (obj_node)
 	{
-		hit_func = get_hit_func(obj_node->data);
-		if (hit_func != NULL
-			&& hit_func(obj_node->data, shadow_ray, 1e-3, &shadow_rec))
+		if (blocks_light(obj_node->data, shadow_ray, light_dist))
 			return (false);
 		obj_node = obj_node->next;
 	}


### PR DESCRIPTION
ライティングに関するバグを修正.

- 衝突点から見て光源より後ろに物体がある場合に `is_illuminated` が `false` になっていた
  - 画像一枚目. 2つの球の間, 上のあたりにライト.
- ライトが面を挟んでカメラと反対側にある場合に光が漏れていた.
  - 画像二枚目. 下面のすぐ下にライト.

<img width="600" alt="スクリーンショット 2024-01-11 5 35 13" src="https://github.com/harsssh/miniRT/assets/66548698/d492fd74-d171-4708-b4ab-48eb15528496">
<img width="600" alt="スクリーンショット 2024-01-11 6 55 41" src="https://github.com/harsssh/miniRT/assets/66548698/4cf90cb2-f8d6-4564-ae34-0fcf5e7b5224">
